### PR TITLE
insert item in db if not exists

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,7 +47,7 @@
   branch = "master"
   name = "github.com/kubeapps/common"
   packages = ["datastore"]
-  revision = "2b565d483a2a36dc97bbc14ef004bc5e10bc3b82"
+  revision = "30a2bbb4f9a1afdd42327f33010d5fe734dbd2b9"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"

--- a/testutil/mockstore.go
+++ b/testutil/mockstore.go
@@ -38,6 +38,11 @@ func (c mockCollection) FindId(id interface{}) datastore.Query {
 	return mockQuery{c.Mock}
 }
 
+func (c mockCollection) Insert(docs ...interface{}) error {
+	c.Called(docs...)
+	return nil
+}
+
 func (c mockCollection) Upsert(selector interface{}, update interface{}) (*mgo.ChangeInfo, error) {
 	return nil, nil
 }
@@ -55,6 +60,10 @@ func (c mockCollection) Remove(selector interface{}) error {
 	return nil
 }
 
+func (c mockCollection) Count() (int, error) {
+	return 0, nil
+}
+
 // mockQuery acts as a mock datastore.Query
 type mockQuery struct {
 	*mock.Mock
@@ -66,7 +75,8 @@ func (q mockQuery) All(result interface{}) error {
 }
 
 func (q mockQuery) One(result interface{}) error {
-	return nil
+	args := q.Called(result)
+	return args.Error(0)
 }
 
 // NewMockSession returns a mocked Session


### PR DESCRIPTION
Before we were updating or inserting an item which had an empty StargazersIDs array. This was resetting the array of Stargazers IDs every time which meant only a single user could start an item at a time.

fixes #1 